### PR TITLE
fix typo of echo-text

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,5 +22,5 @@ runs:
   steps:
     - run: echo User - ${{ inputs.user }}
       shell: bash
-    - run: echo ${{ inputs.echo.text }}
+    - run: echo ${{ inputs.echo-text }}
       shell: bash


### PR DESCRIPTION
change `echo.text` into `exho-text` in echo-action.yml

---

Hi HongLinLiao,

Thanks for the awesome presentation on June 4. Did learn a lot from it!

The output of 'echo-text' is missing in the 'echo-action'. It might be a small typo in the bash script. Please see the following output.
```bash
Run echo 
  echo  # missing the echo text
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
```
[full log](https://github.com/apo1798/learning-github-actions/actions/runs/5195807847/jobs/9368885397)

When I was trying out my own version of reusable actions on GitHub, there's a great way to test whether it works before even publishing to the GitHub Markertplace. 

We can create a test repo, and run the workflows in the repo intended to be pulished in the Markerplace. The following is just an example, feel free to revise to fit your need.

```yml
# .github/workflows/test-action.yml
name: Test action
run-name: ${{ github.actor }} is testing
on: [push]
jobs:
  call-our-workflow:
    runs-on: ubuntu-latest
    steps:
      - name: Test action
        # here we connect to the test workflow
        uses: apo1798/echo-action@a4cb21017013701ac4ae47e60328c16c0cef75ef
        # uses: apo1798/echo-action@main # another alternative
        with:
          user: ${{ github.actor }}
```

The supported `uses` path syntax can be found in the [docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses).

I hope you find this helpful. And thank for your work on the community promotion! Looking forward to meeting you up in the next sharing. ^_^